### PR TITLE
Fix websocket utils import

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { WebSocketServer } = require('ws');
-const setupWSConnection = require('y-websocket/bin/utils.js').setupWSConnection;
+const setupWSConnection = require('y-websocket/bin/utils').setupWSConnection;
 const http = require('http');
 const Database = require('better-sqlite3');
 


### PR DESCRIPTION
## Summary
- use the "y-websocket/bin/utils" export instead of the old file path

## Testing
- `node server/server.js`

------
https://chatgpt.com/codex/tasks/task_b_687d08d86ad0832ebd081248516fd5a1